### PR TITLE
Updated quay image name

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # change these
-CONTAINER_IMAGE=openshift-devsecops-labguides
+CONTAINER_IMAGE=devsecops-workshop-dashboard
 DOCKERFILE_DIR=
 
 function print_usage() {


### PR DESCRIPTION
This aligns the Quay.io image name with the new repository name and convention we've established. It's going to break the workshop, but luckily I've already broken it deeply and haven't fixed it yet so I'd like to include this in the fixes for migration.