### PR TITLE
Lab 14 Fix the event listener:  spec.triggers[0].bindings[0].Value is required

### DIFF
--- a/tekton/workshop/content/lab14.md
+++ b/tekton/workshop/content/lab14.md
@@ -72,6 +72,7 @@ spec:
     - name: gitea-event
       bindings:
         - name: dev-tekton-tasks-trigger-binding
+          value: Dev Tekton Tasks Trigger
       interceptors:
         - cel:
             filter: body.secret == "secret1234"
@@ -158,6 +159,7 @@ spec:
     - name: curl-event
       bindings:
         - name: tasks-stage-pipeline-trigger-binding
+          value: Tasks Stage Pipeline Trigger
       interceptors:
         - cel:
             filter: body.secret == "secret1234"


### PR DESCRIPTION
With the newer version of tekton, creating an event listener spec.triggers[0].bindings[0].Value is required

```
Error from server (BadRequest): error when creating "STDIN": admission webhook "validation.webhook.triggers.tekto
n.dev" denied the request: validation failed: missing field(s): spec.triggers[0].bindings[0].Value
```

Updated lab 14 to include the field